### PR TITLE
Add laundry tracking API and inventory UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ API Endpoints
 - GET /api/health -> {"status":"ok"}
 - GET /api/providers -> Liste verfügbarer Provider
 - POST /api/ai/suggest -> body: {"context":"..."} -> Antwort vom Provider
+- GET /api/laundry/ -> Liste der erfassten Wäschestücke inkl. Status (dirty, washing, drying, clean, folded)
+- POST /api/laundry/ -> Neues Wäschestück anlegen (label, optional material/color/tag_id/status)
+- PATCH /api/laundry/{id} -> Attribute oder Status aktualisieren (inkl. Statuswechsel per Workflow)
+- DELETE /api/laundry/{id} -> Wäschestück entfernen
 
 Configuration
 - Top-level config: config.yaml (ml_provider: local | openai)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,10 +8,12 @@ try:
     # When imported as a package: uvicorn backend.main:app
     from .adapters import get_provider, list_providers  # type: ignore
     from .models.db import create_db  # type: ignore
+    from .routes.laundry import router as laundry_router  # type: ignore
     from .settings import Settings  # type: ignore
 except Exception:  # pragma: no cover - fallback for local runs/tests
     from adapters import get_provider, list_providers
     from models.db import create_db
+    from routes.laundry import router as laundry_router
     from settings import Settings
 
 
@@ -31,6 +33,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+app.include_router(laundry_router)
 
 
 @app.get("/api/health")

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
-from typing import Optional
+from enum import Enum
+from typing import Iterator, Optional
 
-from sqlmodel import Field, SQLModel, create_engine
+from sqlmodel import Field, Session, SQLModel, create_engine
+
+DEFAULT_DATABASE_URL = "sqlite:///./laundry.db"
+
+
+class LaundryStatus(str, Enum):
+    """Lifecycle stages for a tracked laundry item."""
+
+    DIRTY = "dirty"
+    WASHING = "washing"
+    DRYING = "drying"
+    CLEAN = "clean"
+    FOLDED = "folded"
 
 
 class LaundryItem(SQLModel, table=True):
@@ -11,10 +24,32 @@ class LaundryItem(SQLModel, table=True):
     material: Optional[str] = None
     color: Optional[str] = None
     tag_id: Optional[str] = Field(default=None, index=True, unique=True)
+    status: LaundryStatus = Field(default=LaundryStatus.DIRTY, index=True)
 
 
-engine = create_engine("sqlite:///./laundry.db")
+def _create_engine() -> "Engine":
+    from os import getenv
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.pool import StaticPool
+
+    database_url = getenv("LAUNDRY_DATABASE_URL", DEFAULT_DATABASE_URL)
+    connect_args = {"check_same_thread": False} if database_url.startswith("sqlite") else {}
+    if database_url in {"sqlite://", "sqlite:///:memory:"}:
+        return create_engine(
+            "sqlite://",
+            connect_args=connect_args,
+            poolclass=StaticPool,
+        )
+    return create_engine(database_url, connect_args=connect_args)
+
+
+engine = _create_engine()
 
 
 def create_db() -> None:
     SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Iterator[Session]:
+    with Session(engine) as session:
+        yield session

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API routers for the Laundry backend."""

--- a/backend/routes/laundry.py
+++ b/backend/routes/laundry.py
@@ -1,0 +1,104 @@
+"""Laundry tracking endpoints."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlmodel import Session, SQLModel, select
+
+try:  # pragma: no cover - package vs module import convenience
+    from ..models.db import LaundryItem, LaundryStatus, get_session  # type: ignore
+except ImportError:  # pragma: no cover
+    from models.db import LaundryItem, LaundryStatus, get_session
+
+router = APIRouter(prefix="/api/laundry", tags=["laundry"])
+
+
+class LaundryBase(SQLModel):
+    """Shared attributes for laundry payloads."""
+
+    label: str
+    material: str | None = None
+    color: str | None = None
+    tag_id: str | None = None
+
+
+class LaundryCreate(LaundryBase):
+    """Payload for creating items."""
+
+    status: LaundryStatus | None = None
+
+
+class LaundryUpdate(SQLModel):
+    """Partial update payload."""
+
+    label: str | None = None
+    material: str | None = None
+    color: str | None = None
+    tag_id: str | None = None
+    status: LaundryStatus | None = None
+
+
+class LaundryRead(LaundryBase):
+    """Response schema for an item."""
+
+    id: int
+    status: LaundryStatus
+
+
+@router.get("/", response_model=List[LaundryRead])
+async def list_items(session: Session = Depends(get_session)) -> List[LaundryRead]:
+    return session.exec(select(LaundryItem)).all()
+
+
+@router.post("/", response_model=LaundryRead, status_code=status.HTTP_201_CREATED)
+async def create_item(payload: LaundryCreate, session: Session = Depends(get_session)) -> LaundryRead:
+    if payload.tag_id:
+        existing = session.exec(select(LaundryItem).where(LaundryItem.tag_id == payload.tag_id)).first()
+        if existing:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="tag_id already in use")
+    item = LaundryItem(**payload.model_dump(exclude_unset=True))
+    if item.status is None:
+        item.status = LaundryStatus.DIRTY
+    session.add(item)
+    session.commit()
+    session.refresh(item)
+    return item
+
+
+@router.get("/{item_id}", response_model=LaundryRead)
+async def get_item(item_id: int, session: Session = Depends(get_session)) -> LaundryRead:
+    item = session.get(LaundryItem, item_id)
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    return item
+
+
+@router.patch("/{item_id}", response_model=LaundryRead)
+async def update_item(item_id: int, payload: LaundryUpdate, session: Session = Depends(get_session)) -> LaundryRead:
+    item = session.get(LaundryItem, item_id)
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    data = payload.model_dump(exclude_unset=True)
+    if "tag_id" in data and data["tag_id"]:
+        existing = session.exec(select(LaundryItem).where(LaundryItem.tag_id == data["tag_id"], LaundryItem.id != item_id)).first()
+        if existing:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="tag_id already in use")
+    for key, value in data.items():
+        setattr(item, key, value)
+    session.add(item)
+    session.commit()
+    session.refresh(item)
+    return item
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+async def delete_item(item_id: int, session: Session = Depends(get_session)) -> Response:
+    item = session.get(LaundryItem, item_id)
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    session.delete(item)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+

--- a/backend/tests/test_laundry_api.py
+++ b/backend/tests/test_laundry_api.py
@@ -1,0 +1,58 @@
+import os
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
+
+os.environ.setdefault("LAUNDRY_DATABASE_URL", "sqlite://")
+
+from main import app  # noqa: E402  pylint: disable=wrong-import-position
+from models.db import engine  # noqa: E402  pylint: disable=wrong-import-position
+
+
+@pytest.fixture(autouse=True)
+def prepare_db() -> Generator[None, None, None]:
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+    yield
+    SQLModel.metadata.drop_all(engine)
+
+
+def test_create_and_list_items():
+    client = TestClient(app)
+    payload = {"label": "Sportswear", "color": "blue", "status": "washing"}
+    r = client.post("/api/laundry/", json=payload)
+    assert r.status_code == 201
+    created = r.json()
+    assert created["label"] == "Sportswear"
+    assert created["status"] == "washing"
+
+    list_resp = client.get("/api/laundry/")
+    assert list_resp.status_code == 200
+    items = list_resp.json()
+    assert len(items) == 1
+    assert items[0]["label"] == "Sportswear"
+
+
+def test_update_status_and_prevent_duplicate_tags():
+    client = TestClient(app)
+    first = client.post("/api/laundry/", json={"label": "Towels", "tag_id": "tag-1"})
+    second = client.post("/api/laundry/", json={"label": "Bedding", "tag_id": "tag-2"})
+    assert first.status_code == 201
+    assert second.status_code == 201
+    item_id = first.json()["id"]
+
+    update = client.patch(f"/api/laundry/{item_id}", json={"status": "drying"})
+    assert update.status_code == 200
+    assert update.json()["status"] == "drying"
+
+    dup = client.patch(f"/api/laundry/{item_id}", json={"tag_id": "tag-2"})
+    assert dup.status_code == 400
+
+
+
+def test_delete_missing_item():
+    client = TestClient(app)
+    resp = client.delete("/api/laundry/999")
+    assert resp.status_code == 404

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ ml_provider: local
 Environment variables (see .env.example):
 - OPENAI_API_KEY: required if ml_provider=openai
 - HOST (default 0.0.0.0) and PORT (default 8000) for backend
+- LAUNDRY_DATABASE_URL: override default SQLite path (supports sqlite, postgres, etc.)
 - VITE_API_URL for frontend to reach backend (default http://localhost:8000)
 
 Docker Compose

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,19 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+type LaundryStatus = 'dirty' | 'washing' | 'drying' | 'clean' | 'folded'
+
+type LaundryItem = {
+  id: number
+  label: string
+  material?: string | null
+  color?: string | null
+  tag_id?: string | null
+  status: LaundryStatus
+}
+
+const STATUSES: LaundryStatus[] = ['dirty', 'washing', 'drying', 'clean', 'folded']
 
 export default function App() {
   const [health, setHealth] = useState<string>('checking...')
@@ -8,43 +21,200 @@ export default function App() {
   const [suggestion, setSuggestion] = useState('')
   const [provider, setProvider] = useState<string>('')
   const [providers, setProviders] = useState<string[]>([])
+  const [items, setItems] = useState<LaundryItem[]>([])
+  const [formData, setFormData] = useState({
+    label: '',
+    material: '',
+    color: '',
+    tag_id: '',
+    status: 'dirty' as LaundryStatus
+  })
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const refreshLaundry = useCallback(async () => {
+    try {
+      const r = await fetch(`${apiUrl}/api/laundry/`)
+      if (!r.ok) throw new Error('Failed to load laundry items')
+      const data = await r.json()
+      setItems(data)
+    } catch (err) {
+      console.error(err)
+      setItems([])
+    }
+  }, [])
 
   useEffect(() => {
     fetch(`${apiUrl}/api/health`).then(r => r.json()).then(j => setHealth(j.status || 'unknown')).catch(() => setHealth('error'))
-    fetch(`${apiUrl}/api/providers`).then(r => r.json()).then(j => { setProviders(j.providers||[]); setProvider(j.active||'') }).catch(() => {})
-  }, [])
+    fetch(`${apiUrl}/api/providers`).then(r => r.json()).then(j => { setProviders(j.providers || []); setProvider(j.active || '') }).catch(() => {})
+    refreshLaundry()
+  }, [refreshLaundry])
 
   async function onSuggest(e: React.FormEvent) {
     e.preventDefault()
     setSuggestion('...')
-    const r = await fetch(`${apiUrl}/api/ai/suggest`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ context })
-    })
-    const j = await r.json()
-    setSuggestion(j.suggestion || '')
+    try {
+      const r = await fetch(`${apiUrl}/api/ai/suggest`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ context })
+      })
+      const j = await r.json()
+      setSuggestion(j.suggestion || '')
+      if (j.provider) {
+        setProvider(j.provider)
+      }
+    } catch (err) {
+      console.error(err)
+      setSuggestion('Error fetching suggestion')
+    }
+  }
+
+  async function onCreateItem(e: React.FormEvent) {
+    e.preventDefault()
+    setFormError(null)
+    if (!formData.label.trim()) {
+      setFormError('Label is required')
+      return
+    }
+    const payload: Record<string, string> = { label: formData.label.trim(), status: formData.status }
+    if (formData.material.trim()) payload.material = formData.material.trim()
+    if (formData.color.trim()) payload.color = formData.color.trim()
+    if (formData.tag_id.trim()) payload.tag_id = formData.tag_id.trim()
+    try {
+      const r = await fetch(`${apiUrl}/api/laundry/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      if (!r.ok) {
+        const error = await r.json().catch(() => ({ detail: 'Unknown error' }))
+        throw new Error(error.detail)
+      }
+      setFormData({ label: '', material: '', color: '', tag_id: '', status: 'dirty' })
+      refreshLaundry()
+    } catch (err) {
+      console.error(err)
+      setFormError(err instanceof Error ? err.message : 'Failed to create item')
+    }
+  }
+
+  async function onUpdateStatus(id: number, status: LaundryStatus) {
+    try {
+      const r = await fetch(`${apiUrl}/api/laundry/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status })
+      })
+      if (!r.ok) throw new Error('Failed to update item')
+      refreshLaundry()
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function onDeleteItem(id: number) {
+    try {
+      await fetch(`${apiUrl}/api/laundry/${id}`, { method: 'DELETE' })
+      refreshLaundry()
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   return (
-    <div style={{ fontFamily: 'system-ui, sans-serif', margin: '2rem' }}>
+    <div style={{ fontFamily: 'system-ui, sans-serif', margin: '2rem', maxWidth: 900 }}>
       <h1>Laundry AI</h1>
       <p>Backend health: <strong>{health}</strong></p>
       <p>Active provider: <code>{provider}</code></p>
-      <p>Available providers: {providers.join(', ')}</p>
-      <form onSubmit={onSuggest} style={{ marginTop: '1rem' }}>
-        <label>
-          Context:
-          <input value={context} onChange={e => setContext(e.target.value)} style={{ marginLeft: 8, width: 300 }} />
-        </label>
-        <button type="submit" style={{ marginLeft: 8 }}>Suggest</button>
-      </form>
-      {suggestion && (
-        <div style={{ marginTop: '1rem', padding: '1rem', border: '1px solid #ddd' }}>
-          <strong>Suggestion:</strong>
-          <div>{suggestion}</div>
+      <p>Available providers: {providers.join(', ') || '—'}</p>
+
+      <section style={{ marginTop: '2rem' }}>
+        <h2>AI Helper</h2>
+        <form onSubmit={onSuggest} style={{ marginTop: '1rem' }}>
+          <label>
+            Context:
+            <input value={context} onChange={e => setContext(e.target.value)} style={{ marginLeft: 8, width: 300 }} />
+          </label>
+          <button type="submit" style={{ marginLeft: 8 }}>Suggest</button>
+        </form>
+        {suggestion && (
+          <div style={{ marginTop: '1rem', padding: '1rem', border: '1px solid #ddd', background: '#fafafa' }}>
+            <strong>Suggestion:</strong>
+            <div>{suggestion}</div>
+          </div>
+        )}
+      </section>
+
+      <section style={{ marginTop: '2rem' }}>
+        <h2>Laundry Inventory</h2>
+        <form onSubmit={onCreateItem} style={{ display: 'grid', gap: '0.5rem', maxWidth: 500 }}>
+          <div>
+            <label style={{ display: 'block' }}>Label *</label>
+            <input value={formData.label} onChange={e => setFormData(prev => ({ ...prev, label: e.target.value }))} />
+          </div>
+          <div>
+            <label style={{ display: 'block' }}>Material</label>
+            <input value={formData.material} onChange={e => setFormData(prev => ({ ...prev, material: e.target.value }))} />
+          </div>
+          <div>
+            <label style={{ display: 'block' }}>Color</label>
+            <input value={formData.color} onChange={e => setFormData(prev => ({ ...prev, color: e.target.value }))} />
+          </div>
+          <div>
+            <label style={{ display: 'block' }}>Tag ID</label>
+            <input value={formData.tag_id} onChange={e => setFormData(prev => ({ ...prev, tag_id: e.target.value }))} />
+          </div>
+          <div>
+            <label style={{ display: 'block' }}>Initial status</label>
+            <select value={formData.status} onChange={e => setFormData(prev => ({ ...prev, status: e.target.value as LaundryStatus }))}>
+              {STATUSES.map(status => (
+                <option key={status} value={status}>{status}</option>
+              ))}
+            </select>
+          </div>
+          {formError && <p style={{ color: 'red' }}>{formError}</p>}
+          <button type="submit">Add item</button>
+        </form>
+
+        <div style={{ marginTop: '1.5rem' }}>
+          {items.length === 0 ? (
+            <p>No laundry items tracked yet.</p>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left', paddingBottom: 4 }}>Label</th>
+                  <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left', paddingBottom: 4 }}>Material</th>
+                  <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left', paddingBottom: 4 }}>Color</th>
+                  <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left', paddingBottom: 4 }}>Tag</th>
+                  <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left', paddingBottom: 4 }}>Status</th>
+                  <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left', paddingBottom: 4 }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(item => (
+                  <tr key={item.id} style={{ borderBottom: '1px solid #eee' }}>
+                    <td style={{ padding: '0.25rem 0' }}>{item.label}</td>
+                    <td>{item.material || '—'}</td>
+                    <td>{item.color || '—'}</td>
+                    <td>{item.tag_id || '—'}</td>
+                    <td>
+                      <select value={item.status} onChange={e => onUpdateStatus(item.id, e.target.value as LaundryStatus)}>
+                        {STATUSES.map(status => (
+                          <option key={status} value={status}>{status}</option>
+                        ))}
+                      </select>
+                    </td>
+                    <td>
+                      <button type="button" onClick={() => onDeleteItem(item.id)}>Delete</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
-      )}
+      </section>
     </div>
   )
 }

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,10 +1,40 @@
 import { render } from '@testing-library/react'
 import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
 import App from '../src/App'
 
+const responses: Record<string, unknown> = {
+  '/api/health': { status: 'ok' },
+  '/api/providers': { providers: ['local'], active: 'local' },
+  '/api/laundry/': [
+    { id: 1, label: 'Sample Item', material: 'cotton', color: 'white', tag_id: 'abc', status: 'dirty' }
+  ]
+}
+
+function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  const key = Object.keys(responses).find(endpoint => url.endsWith(endpoint))
+  const body = key ? responses[key] : { ok: true }
+  const ok = key !== undefined || (init && init.method && init.method !== 'GET')
+  return Promise.resolve({
+    ok,
+    json: () => Promise.resolve(body)
+  } as unknown as Response)
+}
+
 describe('App', () => {
-  it('renders title', () => {
-    const { getByText } = render(<App />)
-    expect(getByText('Laundry AI')).toBeDefined()
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockImplementation(mockFetch)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders title and inventory data', async () => {
+    const { findByText } = render(<App />)
+    expect(await findByText('Laundry AI')).toBeDefined()
+    expect(await findByText('Sample Item')).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- add a LaundryStatus enum and configurable database engine to support laundry tracking data
- expose CRUD endpoints for laundry items and cover them with FastAPI tests
- build a React laundry inventory dashboard and document the new workflow and configuration knobs

## Testing
- pytest
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68eedaf7b294832b9c9a415bb5d4d59c